### PR TITLE
python version inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There are three user roles:
 ## Quick start
 
 ```bash
-# requires python >=3.10, node >= 20
+# requires python >=3.12, node >= 20
 npm install --prefix web
 npm run build --prefix web/
 pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "A platform for collecting difficult-to-translate texts."
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 authors = [{ name = "Vilém Zouhar", email = "vilem.zouhar@gmail.com" }]
 keywords = [
     "translation",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "A platform for collecting difficult-to-translate texts."
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 authors = [{ name = "Vilém Zouhar", email = "vilem.zouhar@gmail.com" }]
 keywords = [
     "translation",


### PR DESCRIPTION
README.md says ```# requires python >=3.10, node >= 20``` but `pyproject.toml` has `requires-python = ">=3.12"`. Fixed it in README.md