### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@ repos:
     rev: v0.15.12
     hooks:
       - id: ruff
-        args: [check, server]
+        args: [server]
         pass_filenames: false
       - id: ruff
         name: ruff-isort
-        args: [check, --select=I, server]
+        args: [--select=I, server]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        args: [check, server]
+        pass_filenames: false
+      - id: ruff
+        name: ruff-isort
+        args: [check, --select=I, server]
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are three user roles:
 # requires python >=3.12, node >= 20
 npm install --prefix web
 npm run build --prefix web/
-pip install -e .
+pip install -e ".[dev]" && pre-commit install
 # prints login URLs
 python3 server
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ There are three user roles:
 # requires python >=3.12, node >= 20
 npm install --prefix web
 npm run build --prefix web/
-pip install -e ".[dev]" && pre-commit install
+pip install -e ".[dev]" && pre-commit install  # dev: includes linting hooks
+# pip install -e .  # alternatively, if not developing
 # prints login URLs
 python3 server
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = ["pytest", "pre-commit"]
 
 [project.urls]
 Repository = "https://github.com/zouharvi/last-translation-benchmark"

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -1,5 +1,6 @@
-import uvicorn
 import argparse
+
+import uvicorn
 
 args = argparse.ArgumentParser()
 args.add_argument("--port", type=int, default=8000)


### PR DESCRIPTION
Add a pre-commit hook that runs ruff (lint + import order) to catch formatting issues before they reach CI.
Install with pip install -e ".[dev]" && pre-commit install.  Setup instructions added to the README.