### PR TITLE
Change OpenRouter client initialisation

### DIFF
--- a/server/services.py
+++ b/server/services.py
@@ -4,6 +4,7 @@ from openrouter import OpenRouter
 
 from .utils import get_config
 
+_openrouter_client: OpenRouter | None = None
 
 def translate_google(text: str, src_lang: str, tgt_lang: str) -> str:
     return GoogleTranslator(source=src_lang, target=tgt_lang).translate(text)
@@ -29,10 +30,15 @@ def translate_mymemory(text: str, src_lang: str, tgt_lang: str) -> str:
         return data["responseData"]["translatedText"]
     raise Exception(data.get("responseDetails", "API returned an error"))
 
+def _get_client() -> OpenRouter:
+    global _openrouter_client
+    if _openrouter_client is None:
+        _openrouter_client = OpenRouter(api_key=get_config("OPENROUTER_API_KEY", ""))
+    return _openrouter_client
 
 def call_llm(prompt: str, model: str = "google/gemini-2.5-flash-lite") -> str:
     # use openrouter api
-    client = OpenRouter(api_key=get_config("OPENROUTER_API_KEY", ""))
+    client = _get_client()
     response = client.chat.send(
         model=model,
         messages=[


### PR DESCRIPTION
Fixes #29


Tested `call_llm` to check if it's actually running in parallel:
```
import time, threading

def call_llm(prompt: str, model: str = "google/gemini-2.5-flash-lite") -> str:
    t0 = time.time()
    thread = threading.current_thread().name
    client = OpenRouter(api_key=get_config("OPENROUTER_API_KEY", ""))
    response = client.chat.send(
        model=model,
        messages=[
            {
                "role": "user",
                "content": prompt,
            }
        ],
        seed=0,
    )
    elapsed = time.time() - t0
    print(f"[{thread}] {model}: {elapsed:.2f}s")
    return response.choices[0].message.content
```
and I could see different thread names and overlapping timestamps which meant it is parallel. The bottleneck is per-model latency. Saw one low-hanging fruit-- in `call_llm`, we create a new OpenRouter client on every single invocation. Made it global now so that HTTP session (and its connection pool) is shared across all concurrent calls, which cuts latency.

I ran out of tokens for `qwen/qwen3.6-plus` so I used DeepSeek v4 Flash instead.