### PR TITLE
fix: label Gemini translation as "Flash Lite" to match the actual model

### DIFF
--- a/server/routers.py
+++ b/server/routers.py
@@ -269,7 +269,7 @@ async def translate_submission(req: TranslateReq, user=Depends(get_current_user)
         )
     tasks += [
         _run_translate(
-            "Gemini 2.5 Flash",
+            "Gemini 2.5 Flash Lite",
             translate_gemini2_5flash,
             req.text,
             source_name,


### PR DESCRIPTION
## Summary
- The API result row labeled `Gemini 2.5 Flash` is actually produced by `google/gemini-2.5-flash-lite` (see `services.translate_gemini2_5flash`). Reviewers and contributors have been looking at Flash Lite output thinking it's Flash.
- This PR renames the label in `routers.py` so new submissions use the accurate name. The frontend renders API names dynamically, so no UI change is needed.

## Notes
- Existing DB rows keep their stored label. Older submissions are already mixed (some say `Flash Lite`, some say `Flash`); a one-shot migration can normalize them later if desired.
- Alternative fix would be to upgrade the call to actual `google/gemini-2.5-flash`. Not done here because that changes behavior, not just labels.

## Test plan
- [ ] Run the server, translate a sentence as a contributor, confirm the row is labeled `Gemini 2.5 Flash Lite`.
- [ ] Confirm reviewer view shows the corrected label on freshly submitted entries.