### PR TITLE
fix: reviewer comments preserve the existing accept/reject score

### DIFF
--- a/server/routers.py
+++ b/server/routers.py
@@ -422,7 +422,7 @@ async def score_submission(sid: int, req: ScoreReq, user=Depends(get_current_use
         submission["points"] = 1
     elif req.action == "reject":
         submission["points"] = 0
-    else:
+    elif submission.get("points", -1) < 0:
         submission["points"] = -1
     submission["reviewer_comment"] = req.comment or ""
 
@@ -479,7 +479,8 @@ async def add_comment(sid: int, req: CommentReq, user=Depends(get_current_user))
     )
 
     if is_reviewer:
-        submission["points"] = -1
+        if submission.get("points", -1) < 0:
+            submission["points"] = -1
         submission["reviewer_comment"] = req.comment
 
     await save_submission(submission)


### PR DESCRIPTION
## Summary
- Adding a reviewer comment on an already-Accepted or already-Rejected submission was silently un-scoring it (forcing `points = -1`), flipping the badge back to "💬 Commented" and re-surfacing the item in the pending queue.
- Both `score_submission` (action `comment`) and the reviewer path of `add_comment` are patched to only reset `points` when the submission was already pending. Existing accept/reject decisions are preserved.

## Behavior
- Pending submission + comment → still pending (unchanged).
- Accepted/Rejected submission + comment → keeps its score, comment is appended to the thread.

## Test plan
- [ ] Accept a submission, then add a reviewer comment. Confirm the badge stays "✓ Accepted" and it does not reappear in the Pending filter.
- [ ] Reject a submission, then add a comment. Confirm the badge stays "✗ Rejected".
- [ ] Comment on a fresh submission with no prior score. Confirm it shows "💬 Commented" as before.