### PR TITLE
[codex] fix stored XSS in language fields

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "ltb-frontend",
   "scripts": {
     "build": "python3 ../server/languages.py && webpack --mode production",
+    "test": "node tests/language-escaping.test.js",
     "watch": "python3 ../server/languages.py && webpack --mode production --watch",
     "build-dev": "python3 ../server/languages.py && webpack --mode development",
     "watch-dev": "python3 ../server/languages.py && webpack --mode development --watch",

--- a/web/src/contribute.ts
+++ b/web/src/contribute.ts
@@ -537,7 +537,7 @@ function renderMySug(s: Submission): string {
 
     return `<div class="sug-mini">
         <div class="sug-mini-meta" style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">
-            <span>#${s.id} &middot; ${s.source_lang}&rarr;${s.target_lang} &middot; ${fmtDate(s.created_at)} &middot; ${scoreBadge(s.status, (s.comments?.length ?? 0) > 0)}</span>
+            <span>#${s.id} &middot; ${escHtml(s.source_lang)}&rarr;${escHtml(s.target_lang)} &middot; ${fmtDate(s.created_at)} &middot; ${scoreBadge(s.status, (s.comments?.length ?? 0) > 0)}</span>
             ${s.status === 'accept' ? '' : `<button class="score-btn edit-btn" data-id="${s.id}">Edit submission</button>`}
         </div>
         

--- a/web/src/review.ts
+++ b/web/src/review.ts
@@ -207,17 +207,34 @@ function populateFilters(): void {
     const targetLangs = [...new Set([...existingTargetLangs, ...allSugs.map(s => s.target_lang)])].sort();
     const users = [...new Set([...existingUsers, ...allSugs.map(s => s.username)])].sort();
 
-    let mySourceLangsOption = '';
-    let myTargetLangsOption = '';
-    if (currentUser?.roles.includes('admin')) {
-        mySourceLangsOption = `<option value="my_langs" ${sourceLangVal === 'my_langs' ? 'selected' : ''}>My languages only</option>`;
-        myTargetLangsOption = `<option value="my_langs" ${targetLangVal === 'my_langs' ? 'selected' : ''}>My languages only</option>`;
+    const appendLanguageOptions = (
+        selector: string,
+        allLabel: string,
+        currentValue: string,
+        langs: string[],
+    ) => {
+        const $select = $(selector).empty();
+        $select.append($('<option>').val('').text(allLabel));
+        if (currentUser?.roles.includes('admin')) {
+            $select.append(
+                $('<option>')
+                    .val('my_langs')
+                    .text('My languages only')
+                    .prop('selected', currentValue === 'my_langs')
+            );
+        }
+        langs.forEach(lang => {
+            $select.append(
+                $('<option>')
+                    .val(lang)
+                    .text(lang)
+                    .prop('selected', lang === currentValue)
+            );
+        });
     }
 
-    $('#filter-source-lang').html('<option value="">All Source Languages</option>' + mySourceLangsOption +
-        sourceLangs.map(l => `<option value="${l}"${l === sourceLangVal ? ' selected' : ''}>${escHtml(l)}</option>`).join(''));
-    $('#filter-target-lang').html('<option value="">All Target Languages</option>' + myTargetLangsOption +
-        targetLangs.map(l => `<option value="${l}"${l === targetLangVal ? ' selected' : ''}>${escHtml(l)}</option>`).join(''));
+    appendLanguageOptions('#filter-source-lang', 'All Source Languages', sourceLangVal, sourceLangs);
+    appendLanguageOptions('#filter-target-lang', 'All Target Languages', targetLangVal, targetLangs);
     const userDisplay = (u: string) => {
         const existingOption = $(`#filter-user option[value="${u}"]`);
         if (existingOption.length && existingOption.text()) {
@@ -285,7 +302,7 @@ function renderSug(s: Submission): string {
     }).join('');
 
     return `<div class="sug-item" id="sug-${s.id}">
-        <div class="sug-meta">#${s.id} &middot; <b>${escHtml(s.user_name || s.username)}</b> &middot; ${s.source_lang}&rarr;${s.target_lang} &middot; ${fmtDate(s.created_at)} &middot; ${scoreBadge(s.status, (s.comments?.length ?? 0) > 0)}</div>
+        <div class="sug-meta">#${s.id} &middot; <b>${escHtml(s.user_name || s.username)}</b> &middot; ${escHtml(s.source_lang)}&rarr;${escHtml(s.target_lang)} &middot; ${fmtDate(s.created_at)} &middot; ${scoreBadge(s.status, (s.comments?.length ?? 0) > 0)}</div>
         <div class="sug-box" style="margin-bottom:8px"><div class="lbl">INPUT</div>${renderSource(s)}</div>
         <div style="margin-bottom:8px">${trRows}</div>
         <div style="margin-bottom:8px">${ruleRows}</div>

--- a/web/tests/language-escaping.test.js
+++ b/web/tests/language-escaping.test.js
@@ -1,0 +1,58 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+
+function read(relPath) {
+  return fs.readFileSync(path.join(root, relPath), 'utf8');
+}
+
+function assertEscapesLanguageFields(relPath) {
+  const source = read(relPath);
+
+  assert.match(
+    source,
+    /escHtml\(s\.source_lang\)/,
+    `${relPath} must escape source_lang before inserting it into HTML text`,
+  );
+  assert.match(
+    source,
+    /escHtml\(s\.target_lang\)/,
+    `${relPath} must escape target_lang before inserting it into HTML text`,
+  );
+  assert.doesNotMatch(
+    source,
+    /\$\{s\.source_lang\}&rarr;\$\{s\.target_lang\}/,
+    `${relPath} must not render raw language fields`,
+  );
+}
+
+function assertBuildsFilterOptionsWithDomApi(relPath) {
+  const source = read(relPath);
+
+  assert.match(
+    source,
+    /appendLanguageOptions/,
+    `${relPath} must build language filter options via DOM APIs`,
+  );
+  assert.match(
+    source,
+    /\.val\(lang\)/,
+    `${relPath} must set option values without HTML interpolation`,
+  );
+  assert.match(
+    source,
+    /\.text\(lang\)/,
+    `${relPath} must set option labels without HTML interpolation`,
+  );
+  assert.doesNotMatch(
+    source,
+    /<option value="\$\{[^}]*l[^}]*\}"/,
+    `${relPath} must not interpolate language values into option attributes`,
+  );
+}
+
+assertEscapesLanguageFields('src/review.ts');
+assertEscapesLanguageFields('src/contribute.ts');
+assertBuildsFilterOptionsWithDomApi('src/review.ts');


### PR DESCRIPTION
## Summary

Fixes the stored XSS reported in #164 by treating submission language names as untrusted text wherever they are rendered in the frontend.

## Changes

- Escapes `source_lang` and `target_lang` in review and contributor submission metadata.
- Rebuilds review language filter options with jQuery `.val()` and `.text()` so malicious language strings cannot break out of option attributes.
- Adds a lightweight frontend regression test covering the vulnerable language rendering paths.

## Validation

- `npm --prefix web test`
- `npm --prefix web run build`
- Local browser repro with `<img onerror>` and quote-breaking option payloads: both execution markers stayed `null` after loading `/review` and focusing the filter.

Closes #164.
