### PR TITLE
[codex] fix stored XSS in translation results

### DIFF
--- a/web/src/contribute.ts
+++ b/web/src/contribute.ts
@@ -477,7 +477,7 @@ function renderRules() {
 function renderApiResults(): void {
     const $body = $('#api-results-body');
     $body.html(lastResults.map((r, i) => {
-        const trText = r.translation ?? `<em class="tr-error">${escHtml(r.error ?? 'Error')}</em>`;
+        const trText = r.translation !== null ? escHtml(r.translation) : `<em class="tr-error">${escHtml(r.error ?? 'Error')}</em>`;
         const verifyBadge = '';
         return `<div class="translation-result-row">
           <span class="api-name">${escHtml(r.model)}</span>

--- a/web/tests/translation-escaping.test.js
+++ b/web/tests/translation-escaping.test.js
@@ -1,0 +1,42 @@
+const assert = require('node:assert/strict');
+
+function esc(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderApiResultsHtml(results) {
+  return results.map((r, i) => {
+    const trText = r.translation !== null ? esc(r.translation) : `<em class="tr-error">${esc(r.error ?? 'Error')}</em>`;
+    return `<div class="translation-result-row">
+          <span class="api-name">${esc(r.model)}</span>
+          <div class="tr-display">${trText}</div>
+          <div data-idx="${i}" style="display: flex; gap: 4px; flex-wrap: wrap;"></div>
+        </div>`;
+  }).join('');
+}
+
+const maliciousTranslation = '<img src=x onerror="globalThis.__xss = true">';
+const html = renderApiResultsHtml([
+  { model: 'Mock model', translation: maliciousTranslation, error: null },
+  { model: 'Broken model', translation: null, error: '<network failed>' },
+]);
+
+assert.match(
+  html,
+  /&lt;img src=x onerror=&quot;globalThis\.__xss = true&quot;&gt;/,
+  'successful translation text must be HTML-escaped',
+);
+assert.doesNotMatch(
+  html,
+  /<img src=x onerror=/,
+  'successful translation text must not create an HTML element',
+);
+assert.match(
+  html,
+  /<em class="tr-error">&lt;network failed&gt;<\/em>/,
+  'error rows should keep their intentional wrapper while escaping error text',
+);


### PR DESCRIPTION
## Summary

Fixes the contributor-page stored XSS reported in #166 by escaping successful model translation strings before inserting them into result-row HTML.

## Changes

- Escape non-null `r.translation` values in `renderApiResults()`.
- Preserve the existing `<em class="tr-error">` wrapper for error rows while continuing to escape error message text.
- Add a focused Node regression test that renders malicious translation output and checks it remains escaped text.

## Validation

- `node web/tests/translation-escaping.test.js`
- `npm --prefix web run build`
- Local browser repro with a mocked `api/translate-submission` payload: before the fix it set `data-translation-xss=fired`; after the fix the marker stayed `null` and the malicious string rendered as escaped text.

Closes #166.
