### PR TITLE
[codex] Show verification rule tooltips

### DIFF
--- a/web/src/assets/style.css
+++ b/web/src/assets/style.css
@@ -277,6 +277,7 @@ textarea {
   padding: 8px 10px;
   margin-bottom: 6px;
   background: #fafafa;
+  overflow: visible;
 }
 
 .api-name {
@@ -302,21 +303,35 @@ textarea {
 }
 
 .vpill {
-  display: inline-block;
-  padding: 2px 4px;
-  border-radius: 50%;
-  font-size: 0.8em;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  font-size: 0.78em;
   font-weight: 700;
+  line-height: 1;
+  border: 1px solid transparent;
+  cursor: help;
 }
 
 .vpill-pass {
   background: #dcfce7;
   color: #166534;
+  border-color: #bbf7d0;
 }
 
 .vpill-fail {
   background: #fee2e2;
   color: #991b1b;
+  border-color: #fecaca;
+}
+
+.vpill:focus {
+  outline: 2px solid #334155;
+  outline-offset: 2px;
 }
 
 .count-pass {

--- a/web/src/contribute.ts
+++ b/web/src/contribute.ts
@@ -6,7 +6,7 @@ import {
     User, Submission, Rule,
 } from './api';
 
-import { esc as escHtml, fmtDate, scoreBadge, accessDenied, renderCommentThread, renderHeaderStatus, renderSource, sortSubmissions } from './utils';
+import { esc as escHtml, fmtDate, scoreBadge, accessDenied, renderCommentThread, renderHeaderStatus, renderSource, renderVerificationPills, sortSubmissions } from './utils';
 import instructionsHtml from './assets/instructions.html';
 
 let currentUser: User | null = null;
@@ -221,7 +221,7 @@ $(async () => {
                 if (r.translation !== null) {
                     const verified: boolean[] = data.results[resultIdx++];
                     r.verified = verified;
-                    const badge = verified.map(v => v ? '<span class="vpill vpill-pass">✓</span>' : '<span class="vpill vpill-fail">✗</span>').join('');
+                    const badge = renderVerificationPills(verified, rules);
                     $(`[data-idx="${i}"]`).html(badge);
                     if (verified.every(v => v)) pass++;
                 } else {
@@ -232,7 +232,7 @@ $(async () => {
             if (ownTranslation) {
                 const verified: boolean[] = data.results[resultIdx++];
                 ownVerified = verified;
-                const badge = verified.map(v => v ? '<span class="vpill vpill-pass">✓</span>' : '<span class="vpill vpill-fail">✗</span>').join('');
+                const badge = renderVerificationPills(verified, rules);
                 $('#own-verify-badge').html(badge);
                 if (verified.every(v => v)) pass++;
             } else {
@@ -386,7 +386,7 @@ $(async () => {
             $('#own-translation').val(ownTr.translation);
             ownVerified = ownTr.verified;
             if (ownVerified !== null) {
-                const badge = ownVerified.map(v => v ? '<span class="vpill vpill-pass">✓</span>' : '<span class="vpill vpill-fail">✗</span>').join('');
+                const badge = renderVerificationPills(ownVerified, rules);
                 $('#own-verify-badge').html(badge);
             }
         }
@@ -404,7 +404,7 @@ $(async () => {
             // Show verification badges
             lastResults.forEach((r, i) => {
                 if (r.verified != null) {
-                    const badge = r.verified.map(v => v ? '<span class="vpill vpill-pass">✓</span>' : '<span class="vpill vpill-fail">✗</span>').join('');
+                    const badge = renderVerificationPills(r.verified, rules);
                     $(`[data-idx="${i}"]`).html(badge);
                 }
             });

--- a/web/src/review.ts
+++ b/web/src/review.ts
@@ -6,7 +6,7 @@ import {
     Submission, deleteSubmission, addComment,
 } from './api';
 
-import { esc as escHtml, fmtDate, scoreBadge, accessDenied, renderCommentThread, renderHeaderStatus, renderSource, sortSubmissions } from './utils';
+import { esc as escHtml, fmtDate, scoreBadge, accessDenied, renderCommentThread, renderHeaderStatus, renderSource, renderVerificationPills, sortSubmissions } from './utils';
 import instructionsHtml from './assets/instructions.html';
 
 let allSugs: Submission[] = [];
@@ -268,7 +268,7 @@ function renderSug(s: Submission): string {
 
     const trRows = s.translations.map(t => {
         const badge = Array.isArray(t.verified)
-            ? t.verified.map(v => v ? '<span class="vpill vpill-pass">✓</span>' : '<span class="vpill vpill-fail">✗</span>').join('')
+            ? renderVerificationPills(t.verified, s.verification_rules)
             : '';
         return `<div class="translation-result-row">
           <span class="api-name">${escHtml(t.model)}</span>

--- a/web/src/utils.ts
+++ b/web/src/utils.ts
@@ -1,7 +1,15 @@
 import $ from 'jquery';
-import { Comment, Submission, User, handleNotifications } from './api';
+import { Comment, Rule, Submission, User, handleNotifications } from './api';
 
 export const esc = (s: string) => $('<div>').text(s).html();
+function escAttr(s: string): string {
+    return s
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
 export const fmtDate = (d: string) => (d || '').replace('T', ' ').slice(0, 16);
 
 export function renderHeaderStatus(user: User): void {
@@ -71,6 +79,16 @@ export function scoreBadge(status: 'pending' | 'accept' | 'return', hasComments?
     if (status === 'pending') return '<span class="badge badge-pending">Pending</span>';
     if (status === 'accept') return '<span class="badge badge-score-3">✓ Accepted</span>';
     return '<span class="badge badge-score-0">✗ Returned</span>';
+}
+
+export function renderVerificationPills(verified: boolean[], rules: Rule[] = []): string {
+    return verified.map((passed, i) => {
+        const ruleText = rules[i]?.value || `Verification rule ${i + 1}`;
+        const status = passed ? 'pass' : 'fail';
+        const mark = passed ? '✓' : '✗';
+        const label = `${passed ? 'Passed' : 'Failed'}: ${ruleText}`;
+        return `<span class="vpill vpill-${status}" tabindex="0" role="note" title="${escAttr(ruleText)}" aria-label="${escAttr(label)}">${mark}</span>`;
+    }).join('');
 }
 
 function getUsernameColor(username: string): string {


### PR DESCRIPTION
## Summary

Adds rule-level native browser tooltips to verification pass/fail pills on contributor and reviewer translation rows.

## Details

Previously the dense tick/cross columns only showed whether each verification rule passed, so users had to count columns and cross-reference the rule list. The new shared renderer attaches each pill to its rule text with escaped `title` attributes and accessible labels while keeping the UI lightweight.

## Validation

- `npm --prefix web run build`
- `git diff --check`
