### PR TITLE
Show verification rule tooltips

### DIFF
--- a/web/src/contribute.ts
+++ b/web/src/contribute.ts
@@ -6,7 +6,7 @@ import {
     User, Submission, Rule,
 } from './api';
 
-import { esc as escHtml, fmtDate, scoreBadge, accessDenied, renderCommentThread, renderHeaderStatus, renderSource, sortSubmissions } from './utils';
+import { esc as escHtml, fmtDate, scoreBadge, accessDenied, renderCommentThread, renderHeaderStatus, renderSource, renderVerificationPills, sortSubmissions } from './utils';
 import instructionsHtml from './assets/instructions.html';
 
 let currentUser: User | null = null;
@@ -221,7 +221,7 @@ $(async () => {
                 if (r.translation !== null) {
                     const verified: boolean[] = data.results[resultIdx++];
                     r.verified = verified;
-                    const badge = verified.map(v => v ? '<span class="vpill vpill-pass">✓</span>' : '<span class="vpill vpill-fail">✗</span>').join('');
+                    const badge = renderVerificationPills(verified, rules);
                     $(`[data-idx="${i}"]`).html(badge);
                     if (verified.every(v => v)) pass++;
                 } else {
@@ -232,7 +232,7 @@ $(async () => {
             if (ownTranslation) {
                 const verified: boolean[] = data.results[resultIdx++];
                 ownVerified = verified;
-                const badge = verified.map(v => v ? '<span class="vpill vpill-pass">✓</span>' : '<span class="vpill vpill-fail">✗</span>').join('');
+                const badge = renderVerificationPills(verified, rules);
                 $('#own-verify-badge').html(badge);
                 if (verified.every(v => v)) pass++;
             } else {
@@ -386,7 +386,7 @@ $(async () => {
             $('#own-translation').val(ownTr.translation);
             ownVerified = ownTr.verified;
             if (ownVerified !== null) {
-                const badge = ownVerified.map(v => v ? '<span class="vpill vpill-pass">✓</span>' : '<span class="vpill vpill-fail">✗</span>').join('');
+                const badge = renderVerificationPills(ownVerified, rules);
                 $('#own-verify-badge').html(badge);
             }
         }
@@ -404,7 +404,7 @@ $(async () => {
             // Show verification badges
             lastResults.forEach((r, i) => {
                 if (r.verified != null) {
-                    const badge = r.verified.map(v => v ? '<span class="vpill vpill-pass">✓</span>' : '<span class="vpill vpill-fail">✗</span>').join('');
+                    const badge = renderVerificationPills(r.verified, rules);
                     $(`[data-idx="${i}"]`).html(badge);
                 }
             });

--- a/web/src/review.ts
+++ b/web/src/review.ts
@@ -6,7 +6,7 @@ import {
     Submission, deleteSubmission, addComment,
 } from './api';
 
-import { esc as escHtml, fmtDate, scoreBadge, accessDenied, renderCommentThread, renderHeaderStatus, renderSource, sortSubmissions } from './utils';
+import { esc as escHtml, fmtDate, scoreBadge, accessDenied, renderCommentThread, renderHeaderStatus, renderSource, renderVerificationPills, sortSubmissions } from './utils';
 import instructionsHtml from './assets/instructions.html';
 
 let allSugs: Submission[] = [];
@@ -268,7 +268,7 @@ function renderSug(s: Submission): string {
 
     const trRows = s.translations.map(t => {
         const badge = Array.isArray(t.verified)
-            ? t.verified.map(v => v ? '<span class="vpill vpill-pass">✓</span>' : '<span class="vpill vpill-fail">✗</span>').join('')
+            ? renderVerificationPills(t.verified, s.verification_rules)
             : '';
         return `<div class="translation-result-row">
           <span class="api-name">${escHtml(t.model)}</span>

--- a/web/src/utils.ts
+++ b/web/src/utils.ts
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import { Comment, Submission, User, handleNotifications } from './api';
+import { Comment, Rule, Submission, User, handleNotifications } from './api';
 
 export const esc = (s: string) => $('<div>').text(s).html();
 export const fmtDate = (d: string) => (d || '').replace('T', ' ').slice(0, 16);
@@ -71,6 +71,13 @@ export function scoreBadge(status: 'pending' | 'accept' | 'return', hasComments?
     if (status === 'pending') return '<span class="badge badge-pending">Pending</span>';
     if (status === 'accept') return '<span class="badge badge-score-3">✓ Accepted</span>';
     return '<span class="badge badge-score-0">✗ Returned</span>';
+}
+
+export function renderVerificationPills(verified: boolean[], rules: Rule[] = []): string {
+    return verified.map((passed, i) => {
+        const title = esc(rules[i]?.value ?? '').replace(/"/g, '&quot;');
+        return `<span class="vpill vpill-${passed ? 'pass' : 'fail'}" title="${title}">${passed ? '✓' : '✗'}</span>`;
+    }).join('');
 }
 
 function getUsernameColor(username: string): string {


### PR DESCRIPTION
## Summary

Adds the verification rule text as a native browser tooltip on each pass/fail pill in the contributor and reviewer translation rows.

## Details

Previously the dense tick/cross verification columns only showed *whether* each rule passed, so users had to count columns and cross-reference the rule list. This adds a small shared renderer that sets the native HTML `title` attribute (escaped) on each existing `.vpill` span — no custom CSS or tooltip machinery.

This is a minimal reimplementation of #168 per review feedback (use the built-in `title` attribute; keep it to essentially one line).

## Files

- `web/src/utils.ts` — add `renderVerificationPills(verified, rules)`
- `web/src/contribute.ts` / `web/src/review.ts` — use it at the pill call sites

## Validation

- `npm --prefix web run build`
