### PR TITLE
Resolve one language's many spellings to a single name

### DIFF
--- a/scripts/migration/21-normalize_language_names.py
+++ b/scripts/migration/21-normalize_language_names.py
@@ -1,0 +1,68 @@
+import argparse
+import asyncio
+import collections
+
+from last_translation_benchmark.db import (
+    get_submissions,
+    get_users,
+    init_db,
+    save_submission,
+    save_user,
+)
+from last_translation_benchmark.languages import canonicalize_language
+
+
+async def migrate(apply: bool):
+    await init_db()
+    submissions = await get_submissions()
+    users = await get_users()
+
+    renames: collections.Counter = collections.Counter()
+
+    subs_updated = 0
+    for sub in submissions:
+        changed = False
+        for field in ("source_lang", "target_lang"):
+            old = sub.get(field)
+            if not old:
+                continue
+            new = canonicalize_language(old)
+            if new != old:
+                renames[(old, new)] += 1
+                sub[field] = new
+                changed = True
+        if changed:
+            subs_updated += 1
+            if apply:
+                await save_submission(sub)
+
+    # A reviewer scoped to "Persian" is matched against the submission language
+    # by substring, so a stale scope name silently stops routing work to them.
+    users_updated = 0
+    for user in users:
+        review_langs = user.get("review_langs") or []
+        new_langs = [canonicalize_language(x) for x in review_langs]
+        # dedupe while keeping the reviewer's order
+        new_langs = list(dict.fromkeys(new_langs))
+        if new_langs != review_langs:
+            for old, new in zip(review_langs, new_langs, strict=False):
+                if old != new:
+                    renames[(old, new)] += 1
+            user["review_langs"] = new_langs
+            users_updated += 1
+            if apply:
+                await save_user(user)
+
+    for (old, new), count in renames.most_common():
+        print(f"{count:5}  {old!r} -> {new!r}")
+    verb = "Updated" if apply else "Would update"
+    print(f"{verb} {subs_updated} submission(s) and {users_updated} user(s).")
+    if not apply:
+        print("Dry run. Re-run with --apply to write.")
+
+
+if __name__ == "__main__":
+    args = argparse.ArgumentParser()
+    args.add_argument("--apply", action="store_true")
+    args = args.parse_args()
+    asyncio.run(migrate(args.apply))

--- a/scripts/migration/21-normalize_language_names.py
+++ b/scripts/migration/21-normalize_language_names.py
@@ -9,7 +9,7 @@ from last_translation_benchmark.db import (
     save_submission,
     save_user,
 )
-from last_translation_benchmark.languages import canonicalize_language
+from last_translation_benchmark.languages import LANGUAGES, canonicalize_language
 
 
 async def migrate(apply: bool):
@@ -59,6 +59,27 @@ async def migrate(apply: bool):
     print(f"{verb} {subs_updated} submission(s) and {users_updated} user(s).")
     if not apply:
         print("Dry run. Re-run with --apply to write.")
+
+    # Names no rule covers. A variety of a canonical language is listed under it,
+    # because that is where over-specification hides ("German (Germany)"), and the
+    # rest are either languages worth adding to LANGUAGES or one-off typos.
+    canonical = {x["name"] for x in LANGUAGES}
+    off_list: collections.Counter = collections.Counter()
+    for sub in submissions:
+        for field in ("source_lang", "target_lang"):
+            name = sub.get(field)
+            if name and name not in canonical:
+                off_list[name] += 1
+
+    def base_language(name: str) -> str:
+        base = name.split(" (")[0]
+        return base if base in canonical and base != name else ""
+
+    print(f"\n{len(off_list)} name(s) are not in LANGUAGES, for review:")
+    by_base_then_count = sorted(off_list.items(), key=lambda x: (base_language(x[0]), -x[1]))
+    for name, count in by_base_then_count:
+        base = base_language(name)
+        print(f"{count:5}  {name!r}" + (f"  [variety of {base}]" if base else ""))
 
 
 if __name__ == "__main__":

--- a/server/languages.py
+++ b/server/languages.py
@@ -1,3 +1,6 @@
+import re
+import unicodedata
+
 LANGUAGES = [
     {"name": "Acehnese", "code_google": None, "code_lara": "ace-ID"},
     {"name": "Afrikaans", "code_google": "af", "code_lara": "af-ZA"},
@@ -152,8 +155,7 @@ LANGUAGES = [
     {"name": "Nuer", "code_google": None, "code_lara": "nus-SS"},
     {"name": "Nyanja", "code_google": None, "code_lara": "ny-MW"},
     {"name": "Occitan", "code_google": None, "code_lara": "oc-FR"},
-    {"name": "Odia", "code_google": None, "code_lara": "or-IN"},
-    {"name": "Odia (Oriya)", "code_google": "or", "code_lara": None},
+    {"name": "Odia", "code_google": "or", "code_lara": "or-IN"},
     {"name": "Oromo", "code_google": "om", "code_lara": None},
     {"name": "Pangasinan", "code_google": None, "code_lara": "pag-PH"},
     {"name": "Papiamento", "code_google": None, "code_lara": "pap-CW"},
@@ -235,6 +237,83 @@ LANGUAGES = [
     {"name": "Zulu", "code_google": "zu", "code_lara": "zu-ZA"},
     {"name": "American Sign Language", "code_google": None, "code_lara": None},
 ]
+
+# Contributors type languages freely, so the same language arrives under several
+# names. Keys are lowercased and cleaned by _clean_language(); values are the
+# spelling everything collapses to. Only names that already collide in the
+# database are listed here: a variety nobody spelled twice is left as submitted.
+LANGUAGE_ALIASES: dict[str, str] = {
+    # another name for a language that is already in LANGUAGES
+    "farsi": "Persian",
+    "bangla": "Bengali",
+    "français": "French",
+    "odia (oriya)": "Odia",
+    "czech (czech republic)": "Czech",
+    "english (us)": "English (United States)",
+    # one Arabic dialect, up to three spellings; all follow "Arabic (X)"
+    "arabic algerian": "Arabic (Algerian)",
+    "algerian arabic": "Arabic (Algerian)",
+    "algerian (arabic)": "Arabic (Algerian)",
+    "egyptian arabic": "Arabic (Egyptian)",
+    "lebanese arabic": "Arabic (Lebanese)",
+    "arabic tunisian": "Arabic (Tunisian)",
+    "gulf arabic": "Arabic (Gulf)",
+    "jordanian arabic": "Arabic (Jordanian)",
+    "qatari arabic": "Arabic (Qatari)",
+    "sudanese arabic": "Arabic (Sudanese)",
+    "yemeni arabic": "Arabic (Yemeni)",
+    "arabic (maroccan)": "Arabic (Moroccan)",
+    # one variety, two spellings
+    "italian (sicilia)": "Italian (Sicilian)",
+    "neapolitan": "Italian (Neapolitan)",
+    "german (bern)": "Swiss German (Bern)",
+    "german (thüringen)": "German (Thuringia)",
+    "german (austrian)": "German (Austria)",
+    "french (swiss)": "French (Switzerland)",
+    "french lyon": "French (Lyon)",
+    "konkani bardezi": "Konkani (Bardezi)",
+    # case-only twins, whose preferred spelling is not in LANGUAGES
+    "spanish (colombia)": "Spanish (Colombia)",
+    "chinese (guanzhong dialect)": "Chinese (Guanzhong dialect)",
+    "chinese (lanzhou dialect)": "Chinese (Lanzhou dialect)",
+}
+
+_CANONICAL_BY_LOWER = {x["name"].lower(): x["name"] for x in LANGUAGES}
+
+# Reaching a preferred spelling from its own lowercase form, so that typing
+# "arabic (algerian)" also snaps to "Arabic (Algerian)".
+LANGUAGE_ALIASES.update(
+    {
+        name.lower(): name
+        for name in LANGUAGE_ALIASES.values()
+        if name.lower() not in _CANONICAL_BY_LOWER
+    }
+)
+
+
+def _clean_language(name: str) -> str:
+    """Repair spacing, width and invisible characters without renaming."""
+    # NFKC folds fullwidth parentheses, as in "Chinese （Lanzhou Dialect）"
+    name = unicodedata.normalize("NFKC", name)
+    # drop invisible formatting characters, as in the "English‎" submission
+    name = "".join(c for c in name if unicodedata.category(c) != "Cf")
+    name = re.sub(r"\s+", " ", name).strip()
+    name = re.sub(r"\s*\(\s*", " (", name)
+    name = re.sub(r"\s*\)", ")", name)
+    return name.strip()
+
+
+def canonicalize_language(name: str) -> str:
+    """
+    Resolve a submitted language name to the one spelling used for that
+    language, leaving names we have no rule for untouched.
+    """
+    cleaned = _clean_language(name)
+    key = cleaned.lower()
+    if key in _CANONICAL_BY_LOWER:
+        return _CANONICAL_BY_LOWER[key]
+    return LANGUAGE_ALIASES.get(key, cleaned)
+
 
 if __name__ == "__main__":
     import json

--- a/server/routers.py
+++ b/server/routers.py
@@ -34,6 +34,7 @@ from .db import (
 from .db import (
     get_submissions as db_get_submissions,
 )
+from .languages import LANGUAGES, canonicalize_language
 from .models import (
     APILLMReq,
     CommentReq,
@@ -383,6 +384,21 @@ async def admin_overview(user: CurrentUser):
         "submissions_total": submissions_total,
         "pending_languages": pending_languages,
     }
+
+
+@router.get("/api/languages")
+async def languages():
+    # The suggestion list holds the canonical languages plus every variety
+    # somebody already submitted, so a dialect is typed out once rather than
+    # re-invented by the next contributor.
+    submissions = await db_get_submissions()
+    names = {x["name"] for x in LANGUAGES}
+    for s in submissions:
+        for field in ("source_lang", "target_lang"):
+            name = s.get(field)
+            if name:
+                names.add(canonicalize_language(name))
+    return sorted(names)
 
 
 @router.get("/api/public-dashboard")
@@ -849,8 +865,8 @@ async def create_submission(req: SubmissionReq, user: CurrentUser):
         "username": user["username"],
         "source_text": req.source_text,
         "source_media": req.source_media,
-        "source_lang": req.source_lang.strip(),
-        "target_lang": req.target_lang.strip(),
+        "source_lang": canonicalize_language(req.source_lang),
+        "target_lang": canonicalize_language(req.target_lang),
         "verification_rules": [r.dict() for r in req.verification_rules],
         "translations": [t.dict() for t in req.translations],
         "verification_model": req.verification_model,
@@ -890,8 +906,8 @@ async def update_submission(
 
     update: dict = {
         "source_text": req.source_text,
-        "source_lang": req.source_lang,
-        "target_lang": req.target_lang,
+        "source_lang": canonicalize_language(req.source_lang),
+        "target_lang": canonicalize_language(req.target_lang),
         "verification_rules": [r.dict() for r in req.verification_rules],
         "translations": [t.dict() for t in req.translations],
         "verification_model": req.verification_model,

--- a/server/tests/test_languages.py
+++ b/server/tests/test_languages.py
@@ -1,0 +1,57 @@
+"""
+Language names arrive as free text, so canonicalize_language() is what keeps one
+language from being counted as two.
+"""
+
+from last_translation_benchmark.languages import (
+    LANGUAGE_ALIASES,
+    LANGUAGES,
+    canonicalize_language,
+)
+
+
+def test_canonical_names_are_unique():
+    names = [x["name"] for x in LANGUAGES]
+    assert len(names) == len(set(names))
+
+
+def test_aliases_do_not_shadow_a_canonical_name():
+    canonical = {x["name"].lower() for x in LANGUAGES}
+    assert not (set(LANGUAGE_ALIASES) & canonical)
+
+
+def test_endonyms_and_other_names_resolve():
+    assert canonicalize_language("Farsi") == "Persian"
+    assert canonicalize_language("farsi") == "Persian"
+    assert canonicalize_language("Bangla") == "Bengali"
+    assert canonicalize_language("Odia (Oriya)") == "Odia"
+
+
+def test_spacing_width_and_invisible_characters_are_repaired():
+    assert canonicalize_language("Spanish(colombia)") == "Spanish (Colombia)"
+    assert canonicalize_language("Romanian(Moldova)") == "Romanian (Moldova)"
+    assert canonicalize_language("English‎") == "English"
+    assert canonicalize_language("  German  ") == "German"
+    assert (
+        canonicalize_language("Chinese （Lanzhou Dialect）")
+        == "Chinese (Lanzhou dialect)"
+    )
+
+
+def test_dialect_spellings_collapse_to_one():
+    for name in ["Arabic Algerian", "Algerian Arabic", "Algerian (Arabic)"]:
+        assert canonicalize_language(name) == "Arabic (Algerian)"
+    assert canonicalize_language("Neapolitan") == "Italian (Neapolitan)"
+    assert canonicalize_language("German (Bern)") == "Swiss German (Bern)"
+
+
+def test_an_unknown_variety_is_left_alone():
+    assert canonicalize_language("Pnar") == "Pnar"
+    assert canonicalize_language("Chinese (Hunanese, Yueyang)") == (
+        "Chinese (Hunanese, Yueyang)"
+    )
+    # separate languages that only look related
+    assert canonicalize_language("Dari") == "Dari"
+    assert canonicalize_language("Tajik") == "Tajik"
+    assert canonicalize_language("Gilaki") == "Gilaki"
+    assert canonicalize_language("Old Persian") == "Old Persian"

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -195,6 +195,10 @@ export function getPublicDashboard() {
     return apiCall<PublicDashboardData>('GET', 'api/public-dashboard');
 }
 
+export function getLanguages() {
+    return apiCall<string[]>('GET', 'api/languages');
+}
+
 export function createSubmission(data: {
     source_text: string;
     source_media?: string;

--- a/web/src/contribute.ts
+++ b/web/src/contribute.ts
@@ -2,7 +2,7 @@ import './assets/style.css';
 import $ from 'jquery';
 import {
     getMe, getCookie,
-    translate, verify, createSubmission, updateSubmission, getSubmissions, addComment, renderRoleSwitcher, deleteSubmission,
+    translate, verify, createSubmission, updateSubmission, getSubmissions, addComment, renderRoleSwitcher, deleteSubmission, getLanguages,
     User, Submission, Rule,
 } from './api';
 
@@ -32,9 +32,14 @@ $(async () => {
 
     let LANGUAGES: string[] = [];
     try {
-        LANGUAGES = await (await fetch('languages.json')).json();
+        LANGUAGES = await getLanguages();
     } catch (e) {
         console.error('Failed to load languages', e);
+        try {
+            LANGUAGES = await (await fetch('languages.json')).json();
+        } catch (e2) {
+            console.error('Failed to load fallback languages', e2);
+        }
     }
 
     const langOptions = LANGUAGES.map(name => `<option value="${escHtml(name)}">${escHtml(name)}</option>`).join('');


### PR DESCRIPTION
Language fields are free text, so one language reaches the database under several
names and is then counted, translated and reviewed as several languages.
`/api/public-dashboard` currently reports 236 distinct labels; 154 are not in
`server/languages.py`. Most of those are real varieties the canonical list doesn't
cover, which is the point of custom entries — but some are one language wearing two
names: Persian 88 / Farsi 3, Bengali 67 / Bangla 7, Odia 21 / Odia (Oriya) 15,
Arabic Algerian 30 / Algerian Arabic 1 / Algerian (Arabic) 1.

Two costs beyond the inflated language count:

- **Off-list names lose machine translation.** `NAME_TO_CODE_GOOGLE` and
  `NAME_TO_CODE_LARA` are keyed by canonical name, so a submission entered as
  "Farsi" gets no Google or Lara output even though `fa` / `fa-IR` sit under
  "Persian".
- **Off-list names lose reviewers.** `_submission_matches_scope` matches the
  reviewer's scope against the submission language by substring, and "Farsi" is not
  a substring of "Persian" or the reverse, so a reviewer scoped to Persian never
  sees those three submissions.

## What this does

- `canonicalize_language()` in `server/languages.py`: NFKC (folding the fullwidth
  parentheses in `Chinese （Lanzhou Dialect）`), removal of invisible formatting
  characters (one `English` submission carries a U+200E left-to-right mark and is
  therefore its own language), `X(y)` → `X (y)` spacing, then an explicit alias
  table.
- The same call on submission create and update.
- `GET /api/languages`, which suggests the canonical names **plus** every variety
  already submitted. This is the root cause: the datalist offers only the canonical
  names, so every dialect is retyped from scratch and drifts. The contribute page
  falls back to the static `languages.json` if the call fails.
- `scripts/migration/21-normalize_language_names.py`, dry-run by default, rewriting
  existing submissions and reviewer scopes, printing every rename and then every
  name still off-list.
- The two Odia entries merged into one. They split the language to carry one API
  code each (`or` for Google, `or-IN` for Lara), so either choice lost an API.

Only names that **already collide** are merged; a variety nobody spelled twice is
left exactly as submitted. The two conventions applied are the ones the list
already uses (`Chinese (Hong Kong)`, `Kurdish (Sorani)`): base language first,
variety in parentheses.

<details>
<summary>The 34 renames, against the public dashboard's counts</summary>

| collapses to | from |
| --- | --- |
| Persian (88) | Farsi (3) |
| Bengali (67) | Bangla (7) |
| Odia (21) | Odia (Oriya) (15) |
| French (214) | Français (1) |
| Czech (86) | Czech (Czech Republic) (1) |
| English (United States) (93) | English (US) (1) |
| English (2673) | English + U+200E (1) |
| Arabic (Algerian) | Arabic Algerian (30), Algerian Arabic (1), Algerian (Arabic) (1) |
| Arabic (Lebanese) (20) | Lebanese Arabic (3) |
| Arabic (Egyptian) (2) | Egyptian Arabic (4) |
| Arabic (Tunisian) | Arabic Tunisian (10) |
| Arabic (Gulf / Jordanian / Qatari / Sudanese / Yemeni) | the "X Arabic" spellings (2, 1, 1, 1, 2) |
| Arabic (Moroccan) | Arabic (Maroccan) (1) |
| Italian (Neapolitan) (17) | Neapolitan (3) |
| Italian (Sicilian) (2) | Italian (Sicilia) (14) |
| Swiss German (Bern) (2) | German (Bern) (16) |
| German (Thuringia) (2) | German (Thüringen) (1) |
| German (Austria) (2) | German (Austrian) (1) |
| French (Switzerland) (1) | French (Swiss) (5) |
| French (Lyon) (1) | French Lyon (3) |
| Konkani (Bardezi) | Konkani Bardezi (1) |
| Spanish (Colombia) (83) | Spanish(colombia) (4) |
| Chinese (Guanzhong dialect) (3) | Chinese （Guanzhong Dialect） (1) |
| Chinese (Lanzhou dialect) (1) | Chinese （Lanzhou Dialect） (1) |
| Japanese (Tsugaru dialect) (1) | Japanese(Tsugaru dialect) (1) |

236 labels → 213.

</details>

## What is left for someone with database access

I can only see aggregate counts, so these need a look at the submissions
themselves. Each is a line to add to `LANGUAGE_ALIASES`, or a decision to leave
as-is:

- **German (Germany) (21) vs German (287)** — deliberate contrast with the Swiss and
  Austrian entries, or the same thing?
- **Swiss German (34) vs German (Switzerland) (2) vs German (Swiss Standard German) (6)** —
  Swiss German and Swiss Standard German differ; "German (Switzerland)" could be either.
- **Chinese (10)** — Simplified or Traditional? Only the text says.
- **Arabic (MSA) (1) vs Arabic (122)** — the canonical Arabic maps to `ar-SA`, so MSA
  may be worth keeping apart.
- **por (1)** — the ISO code for Portuguese, but `Portuguese`, `Portuguese (Brazil)`
  and `Portuguese (Portugal)` all exist.
- **Any language (1)** — likely a test submission.
- **Ligurian (18) vs Ligurian (Genoese) (8)**, **Japanese (Sendai dialect) (1) vs
  Japanese (Miyagi region) (1)** — sub-variety, or the same thing twice?
- **Mixed Catalan/Spanish (1)** beside **Mixed (Spanish, English)** and
  **Mixed (Hindi, English)** — one pattern for mixed-language sources would help.
- The three **Farsi** submissions are worth reading before the merge: if one is
  really Dari, it should move there instead.

To finish: `python3 scripts/migration/21-normalize_language_names.py` prints what it
would change and then everything still off-list, grouped under the canonical
language it looks like a variety of; `--apply` writes.

Deliberately untouched: `_submission_matches_scope`, since 4571fe9 just changed it
and canonicalizing the names fixes this instance without touching that logic. Also
not merged, for the record: Persian, Dari (0 submissions so far), Tajik (6), Gilaki
(2), Old Persian (1) and Balochi (1) are distinct, as are Ugaritic (7) and
Ugaritic (transliteration) (1).

## Checks

`ruff check server`, `ruff check --select=I server` and `npm run build --prefix web`
all pass. `server/tests/test_languages.py` covers the endonyms, the invisible and
fullwidth characters, the dialect collisions and the varieties that must stay
untouched; I ran its assertions directly rather than under pytest, because the
machine I wrote this on has Python 3.10 and the repo needs ≥3.12, so CI is the first
real pytest run.
