### PR TITLE
add GPT Audio for audio translation

### DIFF
--- a/server/routers.py
+++ b/server/routers.py
@@ -741,6 +741,7 @@ MODEL_LIBRARY = [
     {"name": "Gemini 2.5 Pro", "fn": functools.partial(translate_openrouter, model="google/gemini-2.5-pro"), "support_image": False, "support_audio": True, "support_video": True, "support_textonly": False},
     {"name": "Qwen 3.7 Plus", "fn": functools.partial(translate_openrouter, model="qwen/qwen3.7-plus"), "support_image": False, "support_audio": False, "support_video": True, "support_textonly": False},
     {"name": "Voxtral Small", "fn": functools.partial(translate_openrouter, model="mistralai/voxtral-small-24b-2507"), "support_image": False, "support_audio": True, "support_video": False, "support_textonly": False},
+    {"name": "GPT Audio", "fn": functools.partial(translate_openrouter, model="openai/gpt-audio"), "support_image": False, "support_audio": True, "support_video": False, "support_textonly": False},
     {"name": "Claude Haiku 4.5", "fn": functools.partial(translate_openrouter, model="anthropic/claude-haiku-4.5"), "support_image": True, "support_audio": False, "support_video": False, "support_textonly": True},
     # not used anymore
     # {"name": "Command A", "fn": functools.partial(translate_openrouter, model="cohere/command-a"), "support_image": True, "support_audio": False, "support_video": False, "support_textonly": True},

--- a/server/services.py
+++ b/server/services.py
@@ -34,6 +34,26 @@ NAME_TO_CODE_LARA = {
     x["name"].lower(): x["code_lara"] for x in LANGUAGES if x["code_lara"] is not None
 }
 
+# browsers report .mp3 as audio/mpeg and .wav under any of the aliases below, but
+# OpenAI-served models (openai/gpt-audio) only accept "mp3" or "wav" as the format
+AUDIO_MIME_TO_FORMAT = {
+    "audio/mpeg": "mp3",
+    "audio/mpeg3": "mp3",
+    "audio/mp3": "mp3",
+    "audio/x-mp3": "mp3",
+    "audio/x-mpeg-3": "mp3",
+    "audio/wav": "wav",
+    "audio/wave": "wav",
+    "audio/x-wav": "wav",
+    "audio/x-pn-wav": "wav",
+    "audio/vnd.wave": "wav",
+}
+
+
+def audio_format_from_mime(mime: str) -> str:
+    mime = mime.strip().lower()
+    return AUDIO_MIME_TO_FORMAT.get(mime, mime.split("/")[-1])
+
 
 def translate_google(
     text: str,
@@ -195,6 +215,10 @@ async def call_llm(prompt: str | list[dict], model: str = "google/gemini-3.5-fla
         )
         content = response.choices[0].message.content
         if content is None:
+            # audio models (openai/gpt-audio) put the text in the audio transcript
+            audio = response.choices[0].message.audio
+            content = audio.transcript if audio else None
+        if content is None:
             log(f"None LLM response: {response.choices[0]}")
             return None
 
@@ -259,7 +283,7 @@ async def call_llm_multimodal(
                 "type": "input_audio",
                 "input_audio": {
                     "data": base64_data,
-                    "format": mime.split("/")[1],
+                    "format": audio_format_from_mime(mime),
                 },
             }
         )

--- a/server/tests/audio.py
+++ b/server/tests/audio.py
@@ -1,0 +1,36 @@
+"""
+Audio input handling for audio-capable models such as openai/gpt-audio.
+"""
+
+from last_translation_benchmark.routers import MODEL_LIBRARY
+from last_translation_benchmark.services import audio_format_from_mime
+
+
+def test_audio_format_from_mime():
+    # browsers report .mp3 uploads as audio/mpeg and .wav under several aliases,
+    # but OpenAI-served models only accept "mp3" and "wav"
+    assert audio_format_from_mime("audio/mpeg") == "mp3"
+    assert audio_format_from_mime("audio/mp3") == "mp3"
+    assert audio_format_from_mime("audio/wav") == "wav"
+    assert audio_format_from_mime("audio/x-wav") == "wav"
+    assert audio_format_from_mime("audio/wave") == "wav"
+    assert audio_format_from_mime("audio/vnd.wave") == "wav"
+
+    # casing and stray whitespace from the data URL header
+    assert audio_format_from_mime("AUDIO/MPEG") == "mp3"
+    assert audio_format_from_mime(" audio/wav ") == "wav"
+
+    # unknown types fall back to the subtype
+    assert audio_format_from_mime("audio/ogg") == "ogg"
+    assert audio_format_from_mime("audio/flac") == "flac"
+
+
+def test_gpt_audio_is_registered():
+    gpt_audio = [m for m in MODEL_LIBRARY if m["name"] == "GPT Audio"]
+    assert len(gpt_audio) == 1
+
+    # gpt-audio takes audio (and text) but no image or video
+    assert gpt_audio[0]["support_audio"]
+    assert not gpt_audio[0]["support_image"]
+    assert not gpt_audio[0]["support_video"]
+    assert not gpt_audio[0]["support_textonly"]


### PR DESCRIPTION
Add openai/gpt-audio to the model library as an audio-only model (no image/video, not used for text-only inputs), mirroring Voxtral Small.

Two fixes were needed to make it actually work:

- The input_audio format was derived as mime.split("/")[1], which yields "mpeg" for .mp3 uploads (browsers report them as audio/mpeg) and "x-wav"/"wave" for some .wav uploads. OpenAI-served models only accept "mp3" or "wav" and reject anything else, so the mime type is now mapped to a supported format name. Gemini/Voxtral were lenient about this, so it only surfaced with gpt-audio.

- Audio models return their text under message.audio.transcript when they answer with audio, leaving message.content null. Fall back to the transcript before treating the response as empty.
