### PR TITLE
fix: send Google Translate API key in a header, not the URL

### DIFF
--- a/server/services.py
+++ b/server/services.py
@@ -101,7 +101,7 @@ async def translate_google_with_api(
 
     response = await HTTP_CLIENT.post(
         "https://translation.googleapis.com/language/translate/v2",
-        params={"key": api_key},
+        headers={"X-goog-api-key": api_key},
         data={
             "q": text,
             "source": source_code,


### PR DESCRIPTION
The Google Translate API key is currently passed as a query parameter, so it ends up in the request URL. httpx includes the URL in the message it builds for `raise_for_status()`, and `_run_translate` forwards that message into the per-model result shown in the UI — so credentials can surface in error output.

Google [prescribes `x-goog-api-key`](https://cloud.google.com/docs/authentication/api-keys-use) for REST calls, using this exact endpoint in its example, and notes that the `key` query parameter "includes your API key in the URL, exposing your key to theft through URL scans". [Best practices](https://cloud.google.com/docs/authentication/api-keys-best-practices) says the same.

One line in `server/services.py`. Only the credential moves: the request stays form-encoded, and `raise_for_status()` plus the error-forwarding path in `routers.py` are untouched. The other providers (Lara, OpenRouter, Cohere) already pass credentials via headers or SDK constructors, so this was the only call site with a secret in a URL.

`ruff check server` and `ruff check --select=I server` both pass.

No test added: `server/tests/` holds one placeholder, and `pytest server/tests/` collects nothing from it because `mock.py` doesn't match pytest's `test_*.py` pattern (CI passes only because it spells `pytest server/tests/*.py`). Happy to follow up with that rename plus a test pinning this invariant if useful.
