### PR TITLE
fix: verify_llm crash on empty model output

### DIFF
--- a/scripts/20c-verify_by_extra_models.py
+++ b/scripts/20c-verify_by_extra_models.py
@@ -157,7 +157,8 @@ async def main():
                                 results.append(None)
                                 continue
 
-                            text_clean = res_text.strip().lower().strip(" \t\n\r.,!?\"'*").split()[-1]
+                            tokens = res_text.strip().lower().strip(" \t\n\r.,!?\"'*").split()
+                            text_clean = tokens[-1] if tokens else ""
                             if "pass" in text_clean:
                                 results.append(True)
                             elif "fail" in text_clean:
@@ -224,7 +225,8 @@ async def main():
                         else:
                             try:
                                 # take only the last word, in case the model outputs extra text
-                                text_clean = res_text.strip().lower().replace("*", "").strip(" \t\n\r.,!?\"'%").split()[-1]
+                                tokens = res_text.strip().lower().replace("*", "").strip(" \t\n\r.,!?\"'%").split()
+                                text_clean = tokens[-1] if tokens else ""
                                 result = int(float(text_clean))
                                 if not (0 <= result <= 100):
                                     raise ValueError(f"  Result {result} out of range")

--- a/scripts/41-score_leaderboard.py
+++ b/scripts/41-score_leaderboard.py
@@ -65,7 +65,8 @@ async def main():
                     continue
 
                 try:
-                    text_clean = res_text.strip().lower().strip(" \t\n\r.,!?\"'*").split()[-1]
+                    tokens = res_text.strip().lower().strip(" \t\n\r.,!?\"'*").split()
+                    text_clean = tokens[-1] if tokens else ""
                     if "pass" in text_clean:
                         rule_results.append(True)
                     elif "fail" in text_clean:

--- a/server/services.py
+++ b/server/services.py
@@ -248,7 +248,8 @@ async def verify_llm(
     )
     if text is None:
         raise ValueError("No response from LLM. Try simplifying your input and verification rules.")
-    text_clean = text.strip().lower().strip(" \t\n\r.,!?\"'*").split()[-1]
+    tokens = text.strip().lower().strip(" \t\n\r.,!?\"'*").split()
+    text_clean = tokens[-1] if tokens else ""
     if "pass" in text_clean:
         return True
     elif "fail" in text_clean:


### PR DESCRIPTION
When the model returns an empty string or only punctuation, split()[-1] raises IndexError. Now it takes the last token only when one exists, and empty output falls through to the existing invalid response path.