### PR TITLE
fix: editing a submission forces a needless re-translate

### DIFF
--- a/web/src/contribute.ts
+++ b/web/src/contribute.ts
@@ -423,7 +423,8 @@ $(async () => {
             error: null,
             verified: t.verified
         }));
-        inputCorrespondsToTranslations = false;
+        // the loaded translations match the loaded input; real edits flip this off
+        inputCorrespondsToTranslations = true;
         if (lastResults.length > 0) {
             renderApiResults();
             // Show verification badges


### PR DESCRIPTION
The edit handler set `inputCorrespondsToTranslations` to false, so Verify and Submit stayed disabled until Translate was run again, which spends a quota unit. The loaded translations do match the loaded input.

Now it is set to true, like `clearForm` does. Real edits still flip it off through the existing input handlers, so changing the source text or media still requires a re-translate.